### PR TITLE
Remove outdated code

### DIFF
--- a/files/debug/entrypoint.sh
+++ b/files/debug/entrypoint.sh
@@ -28,11 +28,6 @@ then
   then
       sed -i "s/xdebug\.remote_host \=.*/xdebug\.remote_host\=$HOST/g" /usr/local/etc/php/conf.d/20-xdebug.ini
   fi
-
-  if [ -f /etc/php/7.1/cli/conf.d/20-xdebug.ini ]
-  then
-      sed -i "s/xdebug\.remote_host \=.*/xdebug\.remote_host\=$HOST/g" /etc/php/7.0/cli/conf.d/20-xdebug.ini
-  fi
 else
   rm -rf /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 fi


### PR DESCRIPTION
I don't think this is needed anymore. 

Apart from that, it's not correct anyways: it checks for the config file of PHP 7.1 but changes the config of PHP 7.0.