### PR TITLE
Set connect_back mode for xDebug by default

### DIFF
--- a/7.1/apache/stretch/debug/entrypoint.sh
+++ b/7.1/apache/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.1/cli/stretch/debug/entrypoint.sh
+++ b/7.1/cli/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.1/fpm/stretch/debug/entrypoint.sh
+++ b/7.1/fpm/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.2/apache/stretch/debug/entrypoint.sh
+++ b/7.2/apache/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.2/cli/stretch/debug/entrypoint.sh
+++ b/7.2/cli/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.2/fpm/stretch/debug/entrypoint.sh
+++ b/7.2/fpm/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.3/apache/buster/debug/entrypoint.sh
+++ b/7.3/apache/buster/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.3/apache/stretch/debug/entrypoint.sh
+++ b/7.3/apache/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.3/cli/buster/debug/entrypoint.sh
+++ b/7.3/cli/buster/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.3/cli/stretch/debug/entrypoint.sh
+++ b/7.3/cli/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.3/fpm/buster/debug/entrypoint.sh
+++ b/7.3/fpm/buster/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.3/fpm/stretch/debug/entrypoint.sh
+++ b/7.3/fpm/stretch/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.4/apache/buster/debug/entrypoint.sh
+++ b/7.4/apache/buster/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.4/cli/buster/debug/entrypoint.sh
+++ b/7.4/cli/buster/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/7.4/fpm/buster/debug/entrypoint.sh
+++ b/7.4/fpm/buster/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   

--- a/debug-Dockerfile-block-1
+++ b/debug-Dockerfile-block-1
@@ -10,7 +10,7 @@ RUN echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/20-xdebug.ini &
     echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
     echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
     echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-    echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+    echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
     echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
     echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
 

--- a/files/debug/entrypoint.sh
+++ b/files/debug/entrypoint.sh
@@ -6,7 +6,7 @@ then
   echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
+  echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
   echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
   


### PR DESCRIPTION
When setting the connect_back parameter, PHPStorm instances will be able to connect proactively to the PHP debugging port.
