### PR TITLE
using composer 1.10.17 rather than 2

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -99,7 +99,7 @@ RUN echo "upload_max_filesize = 100M" >> /usr/local/etc/php/conf.d/20-pimcore.in
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_MEMORY_LIMIT -1
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.17 /usr/bin/composer /usr/bin/composer
 
 
 ##<debug>##


### PR DESCRIPTION
Because of compatibility issues, it's best to use 1.10.17 for now.