### PR TITLE
Increase PHP memory limit

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -97,6 +97,7 @@ RUN set -eux; \
         apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer
 
 RUN echo "upload_max_filesize = 100M" >> /usr/local/etc/php/conf.d/20-pimcore.ini; \
+    echo "memory_limit = 256M" >> /usr/local/etc/php/conf.d/20-pimcore.ini; \
     echo "post_max_size = 100M" >> /usr/local/etc/php/conf.d/20-pimcore.ini
 
 ##<version>##


### PR DESCRIPTION
bigger systems (e.g. enterprise demo) need more memory for running assets:install or pimcore installation