### PR TITLE
Install PHP extension sockets

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,7 +19,7 @@ RUN set -eux; \
         libpng-dev libfreetype6-dev libjpeg-dev libxpm-dev libwebp-dev libjpeg62-turbo-dev libonig-dev \
         ufraw; \
     \
-    docker-php-ext-install intl mbstring mysqli bcmath bz2 soap xsl pdo pdo_mysql fileinfo exif zip opcache; \
+    docker-php-ext-install intl mbstring mysqli bcmath bz2 soap xsl pdo pdo_mysql fileinfo exif zip opcache sockets; \
     \
     wget http://www.imagemagick.org/download/ImageMagick.tar.gz; \
         tar -xvf ImageMagick.tar.gz; \


### PR DESCRIPTION
Install PHP ext-sockets, which is [quite common](https://github.com/php-amqplib/php-amqplib/blob/v2.12.3/composer.json#L33).

(Tested w/ `pimcore/pimcore:PHP7.4-apache`)