### PR TITLE
Install imagick for PHP 8 from PECL again

### DIFF
--- a/8.0-Dockerfile-block-1
+++ b/8.0-Dockerfile-block-1
@@ -1,10 +1,4 @@
     docker-php-ext-configure gd -enable-gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-install gd; \
     pecl install -f xmlrpc; \
-    git clone https://github.com/Imagick/imagick; \
-    cd imagick; \
-    phpize && ./configure; \
-    make; \
-    make install; \
-    cd ../; \
-    rm -rf imagick; \
+    pecl install imagick; \


### PR DESCRIPTION
I didn't test this, but as `imagick 3.5.0` with support for PHP 8 [got released yesterday](https://pecl.php.net/package-changelog.php?package=imagick&release=3.5.0), it shouldn't be needed anymore to build it from source.