### PR TITLE
Allow -debug containers run as custom user

### DIFF
--- a/debug-8.0-Dockerfile-block-1
+++ b/debug-8.0-Dockerfile-block-1
@@ -13,6 +13,9 @@ RUN echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/20-xdebug.ini; 
     echo "xdebug.discover_client_host = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
     echo "xdebug.client_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini;
 
+# allow container to run as custom user, this won't work otherwise because config is changed in entrypoint.sh
+RUN chmod -R 0777 /usr/local/etc/php/conf.d
+
 ENV PHP_DEBUG 1
 ENV PHP_IDE_CONFIG serverName=localhost
 

--- a/debug-Dockerfile-block-1
+++ b/debug-Dockerfile-block-1
@@ -15,6 +15,10 @@ RUN echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/20-xdebug.ini; 
     echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
     echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini;
 
+
+# allow container to run as custom user, this won't work otherwise because config is changed in entrypoint.sh
+RUN chmod -R 0777 /usr/local/etc/php/conf.d
+
 ENV PHP_DEBUG 1
 ENV PHP_IDE_CONFIG serverName=localhost
 


### PR DESCRIPTION
`docker-compose.yml` 
```yml
    php-fpm-debug:
        user: '1000:1000'
```

This won't work, because config files are getting modified in `entrypoint.sh`. 
Using `0777` should be fine, since it's just debug anyway (tried `0666` as well, but didn't work 🤔)
