### PR TITLE
Remove redundant xdebug config

### DIFF
--- a/debug-8.0-Dockerfile-block-1
+++ b/debug-8.0-Dockerfile-block-1
@@ -7,12 +7,6 @@ RUN apt-get update; \
     apt-get remove -y autoconf automake libtool nasm make pkg-config libz-dev build-essential g++; \
     apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer;
 
-RUN echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.start_with_request = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.discover_client_host = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.client_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini;
-
 # allow container to run as custom user, this won't work otherwise because config is changed in entrypoint.sh
 RUN chmod -R 0777 /usr/local/etc/php/conf.d
 

--- a/debug-Dockerfile-block-1
+++ b/debug-Dockerfile-block-1
@@ -7,15 +7,6 @@ RUN apt-get update; \
     apt-get remove -y autoconf automake libtool nasm make pkg-config libz-dev build-essential g++; \
     apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer;
 
-RUN echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.remote_connect_back = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini; \
-    echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini;
-
-
 # allow container to run as custom user, this won't work otherwise because config is changed in entrypoint.sh
 RUN chmod -R 0777 /usr/local/etc/php/conf.d
 


### PR DESCRIPTION
We currently do identical xdebug configuration in Dockerfile and inside the entrypoint. I suggest doing this configuration inside the entrypoint only to keep all bits related to xdebug config creation in one place.