### PR TITLE
Test and clean up xdebug config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
 
             -   name: Build Image
                 run: |
+                    set -ex
+
                     DOCKERFILE="${{ matrix.php }}/${{ matrix.variant }}/${{ matrix.distro }}/${{ matrix.debug }}"
 
                     ls -la $DOCKERFILE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,10 +48,10 @@ jobs:
                     docker build . -t pimcore-image
 
                     if [ "${{ matrix.debug }}" == "debug" ]; then
-                        # Make sure xdebug is installed and configred on debug-build
-                        docker run --rm pimcore-image sh -c '! php -m | grep xdebug'
+                        # Make sure xdebug is installed and configured on debug-build
+                        docker run --rm pimcore-image sh -c 'php -m | grep xdebug'
                         docker run --rm pimcore-image test -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
-                        # Check if entrypoint did it's job and generaged xdebug configration
+                        # Check if entrypoint did it's job and generated xdebug configuration
                         docker run --rm pimcore-image php -r 'assert("PHPSTORM" === ini_get("xdebug.idekey"));'
                         docker run --rm -e XDEBUG_HOST=pim.co.re pimcore-image sh -c 'php -i | grep "xdebug.*pim\.co\.re"'
                     else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,19 @@ jobs:
 
                     docker build . -t pimcore-image
 
+                    if [ "${{ matrix.debug }}" == "debug" ]; then
+                        # Make sure xdebug is installed and configred on debug-build
+                        docker run --rm pimcore-image sh -c '! php -m | grep xdebug'
+                        docker run --rm pimcore-image test -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+                        # Check if entrypoint did it's job and generaged xdebug configration
+                        docker run --rm pimcore-image php -r 'assert("PHPSTORM" === ini_get("xdebug.idekey"));'
+                        docker run --rm -e XDEBUG_HOST=pim.co.re pimcore-image sh -c 'php -i | grep "xdebug.*pim\.co\.re"'
+                    else
+                        # Make sure xdebug is neither activated nor configred on non-debug build
+                        docker run --rm pimcore-image sh -c '! php -m | grep xdebug'
+                        docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+                    fi
+
                     if [ "${{ matrix.php }}" == "8.0" ]; then
                         docker run --rm pimcore-image composer create-project pimcore/skeleton:^10.0 pimcore --no-scripts
                     elif [ "${{ matrix.php }}" == "7.1" ]; then

--- a/files/8.0/debug/entrypoint.sh
+++ b/files/8.0/debug/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 
 # if we managed to determine HOST add it to the xdebug config. Otherwise use xdebug's
 # default config.
-if [ -z "$HOST" ]; then
+if [ -n "$HOST" ]; then
   echo "xdebug.client_host = $HOST" >> /usr/local/etc/php/conf.d/20-xdebug.ini
 fi
 

--- a/files/8.0/debug/entrypoint.sh
+++ b/files/8.0/debug/entrypoint.sh
@@ -1,35 +1,30 @@
 #!/bin/bash
 
-if [ "$PHP_DEBUG" == 1 ]
-then
-  echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.start_with_request = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.discover_client_host = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.client_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
+# Override default configuration for xdebug v3.x.
+# See: https://xdebug.org/docs/all_settings
+cat << EOF > /usr/local/etc/php/conf.d/20-xdebug.ini
+xdebug.idekey = PHPSTORM
+xdebug.mode = debug
+xdebug.start_with_request = 1
+EOF
 
-  # if XDEBUG_HOST is manually set
-  HOST="$XDEBUG_HOST"
+# if XDEBUG_HOST is manually set
+HOST="$XDEBUG_HOST"
 
-  # else if check if is Docker for Mac
-  if [ -z "$HOST" ]; then
-      HOST=`getent hosts docker.for.mac.localhost | awk '{ print $1 }'`
-  fi
-
-  # else get host ip
-  if [ -z "$HOST" ]; then
-      HOST=`/sbin/ip route|awk '/default/ { print $3 }'`
-  fi
-
-  # xdebug config
-  if [ -f /usr/local/etc/php/conf.d/20-xdebug.ini ]
-  then
-      sed -i "s/xdebug\.client_host \=.*/xdebug\.client_host\=$HOST/g" /usr/local/etc/php/conf.d/20-xdebug.ini
-  fi
-
-else
-  rm -rf /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+# else if check if is Docker for Mac
+if [ -z "$HOST" ]; then
+  HOST=`getent hosts docker.for.mac.localhost | awk '{ print $1 }'`
 fi
 
+# else get host ip
+if [ -z "$HOST" ]; then
+  HOST=`/sbin/ip route|awk '/default/ { print $3 }'`
+fi
+
+# if we managed to determine HOST add it to the xdebug config. Otherwise use xdebug's
+# default config.
+if [ -z "$HOST" ]; then
+  echo "xdebug.client_host = $HOST" >> /usr/local/etc/php/conf.d/20-xdebug.ini
+fi
 
 exec "$@"

--- a/files/debug/entrypoint.sh
+++ b/files/debug/entrypoint.sh
@@ -1,36 +1,30 @@
 #!/bin/bash
 
-if [ "$PHP_DEBUG" == 1 ]
-then
-  echo "xdebug.idekey = PHPSTORM" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.default_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_enable = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_autostart = 1" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_connect_back = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.profiler_enable = 0" >> /usr/local/etc/php/conf.d/20-xdebug.ini && \
-  echo "xdebug.remote_host = 127.0.0.1" >> /usr/local/etc/php/conf.d/20-xdebug.ini
+# Override default configuration for xdebug v2.x
+# See: https://2.xdebug.org/docs/all_settings
+cat << EOF > /usr/local/etc/php/conf.d/20-xdebug.ini
+xdebug.idekey = PHPSTORM
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+EOF
 
-  # if XDEBUG_HOST is manually set
-  HOST="$XDEBUG_HOST"
+# if XDEBUG_HOST is manually set
+HOST="$XDEBUG_HOST"
 
-  # else if check if is Docker for Mac
-  if [ -z "$HOST" ]; then
-      HOST=`getent hosts docker.for.mac.localhost | awk '{ print $1 }'`
-  fi
-
-  # else get host ip
-  if [ -z "$HOST" ]; then
-      HOST=`/sbin/ip route|awk '/default/ { print $3 }'`
-  fi
-
-  # xdebug config
-  if [ -f /usr/local/etc/php/conf.d/20-xdebug.ini ]
-  then
-      sed -i "s/xdebug\.remote_host \=.*/xdebug\.remote_host\=$HOST/g" /usr/local/etc/php/conf.d/20-xdebug.ini
-  fi
-else
-  rm -rf /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+# else if check if is Docker for Mac
+if [ -z "$HOST" ]; then
+  HOST=`getent hosts docker.for.mac.localhost | awk '{ print $1 }'`
 fi
 
+# else get host ip
+if [ -z "$HOST" ]; then
+  HOST=`/sbin/ip route|awk '/default/ { print $3 }'`
+fi
+
+# if we managed to determine HOST add it to the xdebug config. Otherwise use xdebug's
+# default config.
+if [ -z "$HOST" ]; then
+  echo "xdebug.remote_host = $HOST" >> /usr/local/etc/php/conf.d/20-xdebug.ini
+fi
 
 exec "$@"

--- a/files/debug/entrypoint.sh
+++ b/files/debug/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 
 # if we managed to determine HOST add it to the xdebug config. Otherwise use xdebug's
 # default config.
-if [ -z "$HOST" ]; then
+if [ -n "$HOST" ]; then
   echo "xdebug.remote_host = $HOST" >> /usr/local/etc/php/conf.d/20-xdebug.ini
 fi
 


### PR DESCRIPTION
This PR adds a simple test to CI for sanity-checking xdebug confguration. It also proposes a series of changes to the xdebug configuration shippped with this debug flavor of this images:

- most of the chagnes are refactoring
- xdebug settings which do not change default xdebug configration are dropped
- multiline echo's is replaced with HEREDOC for readability
- since we are building debug-flavors explicitly, dropping `if [ "$PHP_DEBUG" == 1 ]` to always generate xdebug config in entrypoint.

