### PR TITLE
Improve how (changed) files appear on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/build/**                   linguist-generated
+Dockerfile*.template        linguist-language=Dockerfile
+*-Dockerfile-*              linguist-language=Dockerfile
+supervisord.conf            linguist-language=ini


### PR DESCRIPTION
- Exclude everything in `/build` from stats and hide changes in diffs
- Enable `Dockerfile` syntax highlighting for files matching `Dockerfile*.template` or `*-Dockerfile-*`
- Enable `ini` syntax highlighting for `supervisord.conf`