### PR TITLE
PHP: enable sockets extension

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,7 +22,7 @@ RUN set -eux; \
     \
     ##<version>##
     ##</version>##
-    docker-php-ext-install intl mbstring mysqli bcmath bz2 soap xsl pdo pdo_mysql fileinfo exif zip opcache; \
+    docker-php-ext-install intl mbstring mysqli bcmath bz2 soap xsl pdo pdo_mysql fileinfo exif zip opcache sockets; \
     \
     wget http://www.imagemagick.org/download/ImageMagick.tar.gz; \
         tar -xvf ImageMagick.tar.gz; \


### PR DESCRIPTION
It's required for `chrome-php/chrome` - which should be used for #10679