### PR TITLE
Don't overwrite the entrypoint from PHP base image in debug containers

### DIFF
--- a/files/8.0/debug/entrypoint.sh
+++ b/files/8.0/debug/entrypoint.sh
@@ -29,4 +29,4 @@ if [ -n "$HOST" ]; then
   echo "xdebug.client_host = $HOST" >> /usr/local/etc/php/conf.d/20-xdebug.ini
 fi
 
-exec "$@"
+exec docker-php-entrypoint "$@"

--- a/files/8.1/debug/entrypoint.sh
+++ b/files/8.1/debug/entrypoint.sh
@@ -29,4 +29,4 @@ if [ -n "$HOST" ]; then
   echo "xdebug.client_host = $HOST" >> /usr/local/etc/php/conf.d/20-xdebug.ini
 fi
 
-exec "$@"
+exec docker-php-entrypoint "$@"

--- a/files/debug/entrypoint.sh
+++ b/files/debug/entrypoint.sh
@@ -29,4 +29,4 @@ if [ -n "$HOST" ]; then
   echo "xdebug.remote_host = $HOST" >> /usr/local/etc/php/conf.d/20-xdebug.ini
 fi
 
-exec "$@"
+exec docker-php-entrypoint "$@"


### PR DESCRIPTION
The debug variants contain a custom entrypoint that overwrites the one from the base PHP image, which means the debug and non-debug containers behave differently in regard to how the entrypoint can be called.

This PR changes the debug entrypoint to delegate to [the one from the PHP base image](https://github.com/docker-library/php/blob/master/8.1/buster/fpm/docker-php-entrypoint) at the end.