### PR TITLE
restrict composer in php 7.4 to 2.2

### DIFF
--- a/7.4-Dockerfile-block-3
+++ b/7.4-Dockerfile-block-3
@@ -1,3 +1,3 @@
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_MEMORY_LIMIT -1
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2:2 /usr/bin/composer /usr/bin/composer

--- a/7.4-Dockerfile-block-3
+++ b/7.4-Dockerfile-block-3
@@ -1,3 +1,3 @@
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_MEMORY_LIMIT -1
-COPY --from=composer:2:2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
With the release of composer 2.3, the pimcore post scripts in pimcore 6 are broken:

```
In Process.php line 143:
                                                                                                                                                                                              
  [TypeError]                                                                                                                                                                                 
  Argument 1 passed to Symfony\Component\Process\Process::__construct() must be of the type array, string given, called in /var/www/html/vendor/pimcore/pimcore/lib/Composer.php on line 199  
                                                                                                                                                                                              

Exception trace:
  at phar:///usr/bin/composer/vendor/symfony/process/Process.php:143
 Symfony\Component\Process\Process->__construct() at /var/www/html/vendor/pimcore/pimcore/lib/Composer.php:199
 Pimcore\Composer::executeCommand() at /var/www/html/vendor/pimcore/pimcore/lib/Composer.php:360
 Pimcore\Composer::clearCache() at phar:///usr/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:391
 Composer\EventDispatcher\EventDispatcher->executeEventPhpScript() at phar:///usr/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:248
 Composer\EventDispatcher\EventDispatcher->doDispatch() at phar:///usr/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:108
 Composer\EventDispatcher\EventDispatcher->dispatch() at phar:///usr/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:228
 Composer\EventDispatcher\EventDispatcher->doDispatch() at phar:///usr/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:125
 Composer\EventDispatcher\EventDispatcher->dispatchScript() at phar:///usr/bin/composer/src/Composer/Installer.php:372
 Composer\Installer->run() at phar:///usr/bin/composer/src/Composer/Command/InstallCommand.php:137
 Composer\Command\InstallCommand->execute() at phar:///usr/bin/composer/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at phar:///usr/bin/composer/vendor/symfony/console/Application.php:1015
 Symfony\Component\Console\Application->doRunCommand() at phar:///usr/bin/composer/vendor/symfony/console/Application.php:299
 Symfony\Component\Console\Application->doRun() at phar:///usr/bin/composer/src/Composer/Console/Application.php:334
 Composer\Console\Application->doRun() at phar:///usr/bin/composer/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at phar:///usr/bin/composer/src/Composer/Console/Application.php:130
 Composer\Console\Application->run() at phar:///usr/bin/composer/bin/composer:83
 require() at /usr/bin/composer:29

```

I propose to restrict composer to version 2.2 in the php 7.4 container

