### PR TITLE
Entrypoint.sh: Start xdebug on request removed

### DIFF
--- a/files/8.1/debug/entrypoint.sh
+++ b/files/8.1/debug/entrypoint.sh
@@ -7,7 +7,6 @@
 cat << EOF > /usr/local/etc/php/conf.d/20-xdebug.ini
 xdebug.idekey = PHPSTORM
 xdebug.mode = debug
-xdebug.start_with_request = 1
 EOF
 
 # if XDEBUG_HOST is manually set


### PR DESCRIPTION
You can start the debugging with an .env variable or by a cookie setting, see https://xdebug.org/docs/all_settings#start_with_request. Without starting the debugging on  request by default, the image is also usable in prod environment or at least you have the choice if you want debugging in an environment or not.