### PR TITLE
Cleanup `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,1 @@
-/build/**                   linguist-generated
-Dockerfile*.template        linguist-language=Dockerfile
-*-Dockerfile-*              linguist-language=Dockerfile
-supervisord.conf            linguist-language=ini
+supervisord.conf  linguist-language=ini


### PR DESCRIPTION
Since #98 the `build` folder as well as the `Dockerfile` templates and partial `Dockerfile`s are gone.