### PR TITLE
Disable AVIF image format because of performance issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN set -eux; \
     \
     # ImageMagick
     apt-get install -y imagemagick-7 libmagickwand-7-dev; \
+    # Disable AVIF image format because of performance issues, can be removed in Debian bookworm as it has updated avif libraries
+    sed -i '\@</policymap>@i <policy domain="coder" rights="none" pattern="AVIF" />' /etc/ImageMagick-7/policy.xml \
     \
     docker-php-ext-configure gd -enable-gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-install gd; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN set -eux; \
     # ImageMagick
     apt-get install -y imagemagick-7 libmagickwand-7-dev; \
     # Disable AVIF image format because of performance issues, can be removed in Debian bookworm as it has updated avif libraries
-    sed -i '\@</policymap>@i <policy domain="coder" rights="none" pattern="AVIF" />' /etc/ImageMagick-7/policy.xml \
+    sed -i '\@</policymap>@i <policy domain="coder" rights="none" pattern="AVIF" />' /etc/ImageMagick-7/policy.xml; \
     \
     docker-php-ext-configure gd -enable-gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-install gd; \


### PR DESCRIPTION
I think it makes sense to just completely disable AVIF support in ImageMagick because of massive performance issues when converting to AVIF. 

This can be removed for v3 as soon as Debian bookworm was released. 