### PR TITLE
Call build scripts in the same layer they're needed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,18 +59,18 @@ jobs:
                     VERSION_OVERRIDE: "${{ matrix.version-override }}"
                 run: |
                     set -eux;
-                                        
+
                     if [[ "${{ matrix.tag }}" =~ ^v?1.[0-9x]+$ ]]; then
                         imageVariants=("fpm" "debug" "supervisord")
-                    else 
+                    else
                         imageVariants=("min" "default" "max" "debug" "supervisord")
                     fi
-                    
-                    
+
+
                     for imageVariant in ${imageVariants[@]}; do
-                        
+
                         echo "Building image variant $imageVariant"
-                        
+
                         DOCKER_PLATFORMS=linux/amd64,linux/arm64
                         PHP_VERSION=${{ matrix.php }}
                         DEBIAN_VERSION="${{ matrix.distro }}"
@@ -78,10 +78,10 @@ jobs:
                         # for the latest dev branch we use "dev" as the version and not the name of the branch
                         if [ ! -z "$VERSION_OVERRIDE" ]; then
                             VERSION="$VERSION_OVERRIDE"
-                        fi 
-                        
+                        fi
+
                         PHP_SUB_VERSION=$(docker run -i --rm php:${{ matrix.php }}-fpm-${{ matrix.distro }} php -r 'echo PHP_VERSION;')
-                        
+
                         if [ "$imageVariant" = "fpm"  ] || [ "$imageVariant" = "default"  ]; then
                             BASE_TAG="php${{ matrix.php }}"
                             BASE_TAG_DETAILED="php${PHP_SUB_VERSION}"
@@ -89,31 +89,31 @@ jobs:
                             BASE_TAG="php${{ matrix.php }}-$imageVariant"
                             BASE_TAG_DETAILED="php${PHP_SUB_VERSION}-$imageVariant"
                         fi
-                    
+
                         # DEBUG / TEST
                         #BASE_TAG="testv3-$BASE_TAG"
                         #BASE_TAG_DETAILED="testv3-$BASE_TAG_DETAILED"
-                    
-                    
+
+
                         TAG="${BASE_TAG}-${VERSION}"
                         TAG_DETAILED="${BASE_TAG_DETAILED}-${VERSION}"
                         TAGS="--tag ${IMAGE_NAME}:${TAG}"
                         TAGS="$TAGS --tag ${IMAGE_NAME}:${TAG_DETAILED}"
-                        
+
                         # Tag latest with Version build too
                         if [ "true" = "${{ matrix.latest-tag }}" ]; then
                             TAGS="$TAGS --tag ${IMAGE_NAME}:${BASE_TAG}-latest"
-                        fi 
-                        
+                        fi
+
                         # Create tag for major version
                         if [[ $VERSION =~ ^v[0-9]+.[0-9]+$ ]]; then
                             VERSION_MAJOR=${VERSION//.[0-9]/}
                             TAGS="$TAGS --tag ${IMAGE_NAME}:${BASE_TAG}-${VERSION_MAJOR}"
                         fi
-                            
+
                         echo ${TAGS}
-                        
-                        
+
+
                         docker buildx build --output "type=image,push=true" --platform ${DOCKER_PLATFORMS} \
                         --target="pimcore_php_$imageVariant" \
                         --build-arg PHP_VERSION="${PHP_VERSION}" \
@@ -121,14 +121,12 @@ jobs:
                         --cache-from "type=local,src=/tmp/.buildx-cache" \
                         --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
                         ${TAGS} .
-                    
-                        docker buildx imagetools inspect ${IMAGE_NAME}:${TAG} || true; 
+
+                        docker buildx imagetools inspect ${IMAGE_NAME}:${TAG} || true;
                     done
-                    
+
 
             -   name: Move cache
                 run: |
                     rm -rf /tmp/.buildx-cache
                     mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-                    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     pull_request:
 
 env:
+    DOCKER_BUILDKIT: 1
     IMAGE_NAME: pimcore/pimcore
 
 jobs:
@@ -19,12 +20,12 @@ jobs:
             -   name: Build Image
                 run: |
                     set -ex
-                    
+
                     imageVariants=("min" "default" "max" "debug" "supervisord")
-                    
+
                     for imageVariant in ${imageVariants[@]}; do
                         docker build --tag pimcore-image --target="pimcore_php_$imageVariant" --build-arg PHP_VERSION="${{ matrix.php }}" --build-arg DEBIAN_VERSION="${{ matrix.distro }}" .
-                    
+
                         if [ "$imageVariant" == "debug" ]; then
                             # Make sure xdebug is installed and configured on debug-build
                             docker run --rm pimcore-image sh -c 'php -m | grep xdebug'
@@ -37,9 +38,9 @@ jobs:
                             docker run --rm pimcore-image sh -c '! php -m | grep xdebug'
                             docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
                         fi
-                        
+
                         docker run --rm pimcore-image composer create-project pimcore/skeleton:11.x-dev pimcore --no-scripts
-                    
+
                         if [ "$imageVariant" != "min" ]; then
                             docker run -v "$(pwd)/.github/files":/var/www/html --rm pimcore-image php test_heif.php
                         fi


### PR DESCRIPTION
Each `RUN` instruction creates a new layer, so the removed stuff will still remain in the previous layer. This leads to huge image sizes.

Before: 3.61GB, max. variant
After: 2.78GB, max. variant

The code style was slightly changed as well, in order to sort multi-line arguments.
See: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments