### PR TITLE
PHP 8.3 with Imagick from master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
                     - { tag: 'v3.1', php: '8.2', distro: bookworm, version-override: "", latest-tag: false }
                     - { tag: 'v3.2', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '3.x', php: '8.2', distro: bookworm, version-override: "v3-dev", latest-tag: false }
+                    - { tag: '3.x', php: '8.3', distro: bookworm, version-override: "v3-dev", latest-tag: false }
 
         steps:
             -   uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '8.2' ]
+                php: [ '8.2', '8.3' ]
                 distro: [ bookworm ]
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,11 @@ jobs:
                     for imageVariant in ${imageVariants[@]}; do
                         docker build --tag pimcore-image --target="pimcore_php_$imageVariant" --build-arg PHP_VERSION="${{ matrix.php }}" --build-arg DEBIAN_VERSION="${{ matrix.distro }}" .
 
+                        if [ "$imageVariant" != "min" ]; then
+                            # Test that Imagick is installed
+                            docker run --rm pimcore-image sh -c 'php -m | grep imagick'
+                        fi
+                    
                         if [ "$imageVariant" == "debug" ]; then
                             # Make sure xdebug is installed and configured on debug-build
                             docker run --rm pimcore-image sh -c 'php -m | grep xdebug'

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,14 +139,23 @@ RUN set -eux; \
     \
     pecl install -f \
         apcu \
-        imagick \
+        # imagick \
         redis \
     ; \
     docker-php-ext-enable \
         apcu \
-        imagick \
+        # imagick \
         redis \
     ; \
+    \
+    # Install Imagick from source as long as no official version compatible with PHP 8.3 is released yet
+    # See https://github.com/Imagick/imagick/issues/640
+    # Delete and uncomment imagick in the pecl install above when an official version is released
+    mkdir -p /usr/src/php/ext/imagick; \
+    # Locking on specific commit hash to provide consistent results, at the moment of writing this is the HEAD of master
+    curl -fsSL https://github.com/Imagick/imagick/archive/28f27044e435a2b203e32675e942eb8de620ee58.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+    docker-php-ext-install imagick; \
+    # End install Imagick from source
     \
     build-cleanup.sh; \
     \


### PR DESCRIPTION
With Ubuntu 24.04 out now for a month which is shipped with PHP 8.3 and where Imagick can simply be installed via `apt install php-imagick`, I don't think we should longer lack behind.

https://github.com/Imagick/imagick/issues/640 has multiple mentions of installing Imagick from master and since that issue is open for half a year already I don't see any version being released soon (sorry for my pessimistic attitude).

I do see this as a temporary solution, of course the manual download should be reverted at the moment Imagic does release the new official version.

# Test results:
1. Docker build test is successful (will be triggered again in this PR but wanted to be sure before I opened this one): https://github.com/youwe-petervanderwal/docker/actions/runs/9187199518/job/25264375358
2. Tested `pimcore/demo` with both PHP 8.2 and 8.3 (locally build Docker images and connected these in the docker-compose), results:

### PHP 8.2 test
```
$ docker-compose exec php php -v
PHP 8.2.19 (cli) (built: May 14 2024 13:16:54) (NTS)
```

![Screenshot from 2024-05-22 09-12-48](https://github.com/pimcore/docker/assets/60703382/4d90c320-1ac6-448a-a467-07b721f05a02)

Using Gaussian Blur on Thumbnail definition:
![Screenshot from 2024-05-22 09-13-17](https://github.com/pimcore/docker/assets/60703382/a5ba4d1e-c688-4a9d-9527-5952457281f6)

### PHP 8.3 test
```
$ docker-compose exec php php -v
PHP 8.3.7 (cli) (built: May 14 2024 12:46:30) (NTS)
```

![Screenshot from 2024-05-22 09-25-34](https://github.com/pimcore/docker/assets/60703382/15423059-5085-4d5b-bb9b-8787be7213f3)

Using Gaussian Blur on Thumbnail definition:
![image](https://github.com/pimcore/docker/assets/60703382/d5b15085-2d0c-4e91-a44b-a519c82b2779)

![Screenshot from 2024-05-22 09-26-46](https://github.com/pimcore/docker/assets/60703382/d55b02a6-95e8-48c2-818c-d8b9ffe0a08b)

