### PR TITLE
Configure Imagick version via build argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
                     - { tag: 'v3.1', php: '8.2', distro: bookworm, version-override: "", latest-tag: false }
                     - { tag: 'v3.2', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '3.x', php: '8.2', distro: bookworm, version-override: "v3-dev", latest-tag: false }
-                    - { tag: '3.x', php: '8.3', distro: bookworm, version-override: "v3-dev", latest-tag: false }
+                    - { tag: '3.x', php: '8.3', distro: bookworm, imagick_version_from_src: 28f27044e435a2b203e32675e942eb8de620ee58, version-override: "v3-dev", latest-tag: false }
 
         steps:
             -   uses: actions/checkout@v3
@@ -119,12 +119,13 @@ jobs:
 
 
                         docker buildx build --output "type=image,push=true" --platform ${DOCKER_PLATFORMS} \
-                        --target="pimcore_php_$imageVariant" \
-                        --build-arg PHP_VERSION="${PHP_VERSION}" \
-                        --build-arg DEBIAN_VERSION="${DEBIAN_VERSION}" \
-                        --cache-from "type=local,src=/tmp/.buildx-cache" \
-                        --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
-                        ${TAGS} .
+                            --target="pimcore_php_$imageVariant" \
+                            --build-arg PHP_VERSION="${PHP_VERSION}" \
+                            --build-arg DEBIAN_VERSION="${DEBIAN_VERSION}" \
+                            --build-arg IMAGICK_VERSION_FROM_SRC="${{ matrix.imagick_version_from_src }}" \
+                            --cache-from "type=local,src=/tmp/.buildx-cache" \
+                            --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
+                            ${TAGS} .
 
                         docker buildx imagetools inspect ${IMAGE_NAME}:${TAG} || true;
                     done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,9 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '8.2', '8.3' ]
-                distro: [ bookworm ]
+                include:
+                    - { php: '8.2', distro: bookworm }
+                    - { php: '8.3', distro: bookworm, imagick_version_from_src: 28f27044e435a2b203e32675e942eb8de620ee58 }
         steps:
             -   uses: actions/checkout@v2
             -   name: Build Image
@@ -24,7 +25,12 @@ jobs:
                     imageVariants=("min" "default" "max" "debug" "supervisord")
 
                     for imageVariant in ${imageVariants[@]}; do
-                        docker build --tag pimcore-image --target="pimcore_php_$imageVariant" --build-arg PHP_VERSION="${{ matrix.php }}" --build-arg DEBIAN_VERSION="${{ matrix.distro }}" .
+                        docker build --tag pimcore-image \
+                            --target="pimcore_php_$imageVariant" \
+                            --build-arg PHP_VERSION="${{ matrix.php }}" \
+                            --build-arg DEBIAN_VERSION="${{ matrix.distro }}" \
+                            --build-arg IMAGICK_VERSION_FROM_SRC="${{ matrix.imagick_version_from_src }}" \
+                            .
 
                         if [ "$imageVariant" != "min" ]; then
                             # Test that Imagick is installed


### PR DESCRIPTION
Follow-up on #162 

- Install Imagick from PECL for PHP 8.2
- Install Imagick from source for PHP 8.3

Managed via workflow matrix setting `imagick_version_from_src` so that it's easily configurable per version.

Verified build result:

PHP 8.2 (link should go to step "Build Image", line 6399): https://github.com/youwe-petervanderwal/docker/actions/runs/9197395389/job/25297730594#step:4:6400
PHP 8.3 (link should go to step "Build Image", line 6406): https://github.com/youwe-petervanderwal/docker/actions/runs/9197395389/job/25297730846#step:4:6407 