### PR TITLE
[Tests] Use new main branch for pimcore/skeleton

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
                             docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
                         fi
 
-                        docker run --rm pimcore-image composer create-project pimcore/skeleton:11.x-dev pimcore --no-scripts
+                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2024.x-dev pimcore --no-scripts
 
                         if [ "$imageVariant" != "min" ]; then
                             docker run -v "$(pwd)/.github/files":/var/www/html --rm pimcore-image php test_heif.php


### PR DESCRIPTION
Default branch for pimcore/skeleton was renamed from `11.x` to `2024.x`, therefore tests are not working anymore 