### PR TITLE
Debug image flavor: it should be possible to use any local Git repository in Composer for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
     \
     build-cleanup.sh; \
     \
+    # For local development, it should be possible to use any local (Git) Composer repository - that's safe in debug image flavor
+    git config --global --add safe.directory "*"  \
+    \
     # Allow running as an arbitrary user, as the config will be changed through
     # the entrypoint.sh script
     chmod -R 0777 /usr/local/etc/php/conf.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,7 +219,7 @@ RUN set -eux; \
     build-cleanup.sh; \
     \
     # For local development, it should be possible to use any local (Git) Composer repository - that's safe in debug image flavor
-    git config --global --add safe.directory "*"  \
+    git config --global --add safe.directory "*"; \
     \
     # Allow running as an arbitrary user, as the config will be changed through
     # the entrypoint.sh script


### PR DESCRIPTION
Avoids issues that Composer isn't able to run `git` in local repositories and then falls back to `dev-main` as the version for the repository, that potentially doesn't match with given contraints in root composer.json. 