### PR TITLE
Run build on ubuntu-22.04 image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
     build-php:
         name: "Build PHP images"
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         if: github.repository == 'pimcore/docker'
         strategy:
             matrix:


### PR DESCRIPTION
It seems that there are some major issues with the current `ubuntu-latest` https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250120.5 

See also failing builds (unable to compile PHP extensions): 
https://github.com/pimcore/docker/actions/runs/12942269329/job/36099703127#step:7:2891