### PR TITLE
Update Imagick to 3.8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
                     - { tag: 'v2.0', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: '2.x', php: '8.2', distro: bullseye, version-override: "v2-dev", latest-tag: false }
                     - { tag: 'v3.5', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }
-                    - { tag: 'v3.5', php: '8.3', distro: bookworm, imagick_version_from_src: refs/tags/3.8.0RC2, version-override: "", latest-tag: true }
+                    - { tag: 'v3.5', php: '8.3', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '3.x', php: '8.2', distro: bookworm, version-override: "v3-dev", latest-tag: false }
-                    - { tag: '3.x', php: '8.3', distro: bookworm, imagick_version_from_src: refs/tags/3.8.0RC2, version-override: "v3-dev", latest-tag: false }
-                    - { tag: '4.x', php: '8.3', distro: bookworm, imagick_version_from_src: refs/tags/3.8.0RC2, version-override: "v4-dev", latest-tag: false }
-                    - { tag: '4.x', php: '8.4', distro: bookworm, imagick_version_from_src: refs/tags/3.8.0RC2, version-override: "v4-dev", latest-tag: false }
+                    - { tag: '3.x', php: '8.3', distro: bookworm, version-override: "v3-dev", latest-tag: false }
+                    - { tag: '4.x', php: '8.3', distro: bookworm, version-override: "v4-dev", latest-tag: false }
+                    - { tag: '4.x', php: '8.4', distro: bookworm, version-override: "v4-dev", latest-tag: false }
 
         steps:
             -   uses: actions/checkout@v4
@@ -100,7 +100,6 @@ jobs:
                             --target="pimcore_php_$imageVariant" \
                             --build-arg PHP_VERSION="${PHP_VERSION}" \
                             --build-arg DEBIAN_VERSION="${DEBIAN_VERSION}" \
-                            --build-arg IMAGICK_VERSION_FROM_SRC="${{ matrix.build.imagick_version_from_src }}" \
                             ${TAGS} .
 
                         docker inspect ${IMAGE_NAME}:${TAG} || true;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - { php: '8.3', distro: bookworm, imagick_version_from_src: refs/tags/3.8.0RC2 }
-                    - { php: '8.4', distro: bookworm, imagick_version_from_src: refs/tags/3.8.0RC2 }
+                    - { php: '8.3', distro: bookworm }
+                    - { php: '8.4', distro: bookworm }
         steps:
             -   uses: actions/checkout@v2
             -   name: Build Image
@@ -29,7 +29,6 @@ jobs:
                             --target="pimcore_php_$imageVariant" \
                             --build-arg PHP_VERSION="${{ matrix.php }}" \
                             --build-arg DEBIAN_VERSION="${{ matrix.distro }}" \
-                            --build-arg IMAGICK_VERSION_FROM_SRC="${{ matrix.imagick_version_from_src }}" \
                             .
 
                         if [ "$imageVariant" != "min" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,8 +97,6 @@ CMD ["php-fpm"]
 
 FROM pimcore_php_min AS pimcore_php_default
 
-ARG IMAGICK_VERSION_FROM_SRC="";
-
 RUN set -eux; \
     \
     build-install.sh; \
@@ -142,25 +140,14 @@ RUN set -eux; \
     \
     pecl install -f \
         apcu \
+        imagick \
         redis \
     ; \
     docker-php-ext-enable \
         apcu \
+        imagick \
         redis \
     ; \
-    \
-    # Install Imagick from PECL if no build arg IMAGICK_VERSION_FROM_SRC is given
-    [ -z "$IMAGICK_VERSION_FROM_SRC" ] && \
-        pecl install -f imagick && \
-        docker-php-ext-enable imagick; \
-    \
-    # Install Imagick from source as long as no official version compatible with PHP 8.3 is released yet
-    # See https://github.com/Imagick/imagick/issues/640
-    # Provide the build argument IMAGICK_VERSION_FROM_SRC containing a commit hash or "refs/tags/3.7.0" or "refs/heads/master"
-    [ -n "$IMAGICK_VERSION_FROM_SRC" ] &&  \
-        mkdir -p /usr/src/php/ext/imagick && \
-        curl -fsSL https://github.com/Imagick/imagick/archive/"$IMAGICK_VERSION_FROM_SRC".tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1 && \
-        docker-php-ext-install imagick; \
     \
     build-cleanup.sh; \
     \


### PR DESCRIPTION
The final version of Imagick with support for PHP 8.3 and 8.4 has just been released 🎉 https://github.com/Imagick/imagick/releases/tag/3.8.0

It's also on PECL already: https://pecl.php.net/package-info.php?package=imagick&version=3.8.0

This PR removes the workaround that enabled us to install it from source.