### PR TITLE
Switch to https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN set -eux; \
     DPKG_ARCH="$(dpkg --print-architecture)"; \
     apt-get update; \
     apt-get install -y lsb-release; \
-    echo "deb http://archive.debian.org/debian $(lsb_release -sc)-backports main" > /etc/apt/sources.list.d/backports.list; \
+    echo "deb https://archive.debian.org/debian $(lsb_release -sc)-backports main" > /etc/apt/sources.list.d/backports.list; \
     echo "deb https://www.deb-multimedia.org $(lsb_release -sc) main non-free" > /etc/apt/sources.list.d/deb-multimedia.list; \
     apt-get update -oAcquire::AllowInsecureRepositories=true; \
     apt-get install -y --allow-unauthenticated deb-multimedia-keyring; \


### PR DESCRIPTION
This pull request includes a small but important change to the `Dockerfile` to improve security by switching from HTTP to HTTPS for a Debian backports repository.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10-R10): Updated the URL for the Debian backports repository from `http` to `https` to ensure secure connections when fetching packages.