### PR TITLE
Workflows update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
                 build:
                     - { tag: '1.x', php: '8.1', distro: bullseye, version-override: "v1-dev", latest-tag: false }
                     - { tag: '1.x', php: '8.2', distro: bullseye, version-override: "v1-dev", latest-tag: false }
-                    # - { tag: 'v1.3', php: '8.1', distro: bullseye, version-override: "", latest-tag: true }
-                    # - { tag: 'v1.3', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
-                    # - { tag: 'v2.0', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
+                    - { tag: 'v1.4', php: '8.1', distro: bullseye, version-override: "", latest-tag: true }
+                    - { tag: 'v1.4', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
+                    - { tag: 'v2.1', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: '2.x', php: '8.2', distro: bullseye, version-override: "v2-dev", latest-tag: false }
                     - { tag: 'v3.6', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: 'v3.6', php: '8.3', distro: bookworm, version-override: "", latest-tag: true }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
                     - { tag: '1.x', php: '8.2', distro: bullseye, version-override: "v1-dev", latest-tag: false }
                     - { tag: 'v1.3', php: '8.1', distro: bullseye, version-override: "", latest-tag: true }
                     - { tag: 'v1.3', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
-                    - { tag: 'v2.0', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
+                    # - { tag: 'v2.0', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: '2.x', php: '8.2', distro: bullseye, version-override: "v2-dev", latest-tag: false }
                     - { tag: 'v3.6', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: 'v3.6', php: '8.3', distro: bookworm, version-override: "", latest-tag: true }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
                 build:
                     - { tag: '1.x', php: '8.1', distro: bullseye, version-override: "v1-dev", latest-tag: false }
                     - { tag: '1.x', php: '8.2', distro: bullseye, version-override: "v1-dev", latest-tag: false }
-                    - { tag: 'v1.3', php: '8.1', distro: bullseye, version-override: "", latest-tag: true }
-                    - { tag: 'v1.3', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
+                    # - { tag: 'v1.3', php: '8.1', distro: bullseye, version-override: "", latest-tag: true }
+                    # - { tag: 'v1.3', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     # - { tag: 'v2.0', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: '2.x', php: '8.2', distro: bullseye, version-override: "v2-dev", latest-tag: false }
                     - { tag: 'v3.6', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }


### PR DESCRIPTION
This pull request updates the release workflow configuration in `.github/workflows/release.yml` to reflect new version tags for builds. The changes ensure the workflow uses updated versioning for PHP builds.

### Updates to build version tags:
* Replaced `v1.3` with `v1.4` for PHP 8.1 and 8.2 builds, updating the latest tag for PHP 8.1 to `true`.
* Replaced `v2.0` with `v2.1` for PHP 8.2 builds.