### PR TITLE
Allow TZ override via ENV variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY files/conf/php/php.ini /usr/local/etc/php/conf.d/20-pimcore.ini
 COPY files/conf/php-fpm/php-fpm.conf /usr/local/etc/php-fpm.d/zz-www.conf
 
 # env php.ini
+ENV PHP_TIMEZONE "UTC"
 ENV PHP_MEMORY_LIMIT "256M"
 ENV PHP_POST_MAX_SIZE "100M"
 ENV PHP_UPLOAD_MAX_FILESIZE "100M"

--- a/files/conf/php/php.ini
+++ b/files/conf/php/php.ini
@@ -1,3 +1,5 @@
+date.timezone = ${PHP_TIMEZONE}
+
 memory_limit = ${PHP_MEMORY_LIMIT}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 error_reporting = ${PHP_ERROR_REPORTING}


### PR DESCRIPTION
This MR adds the ability to specify the date.timezone PHP config value using an environment variable, which is very beneficial for containerized environments depending on the upstream images. 

In the Dockerfile I've set the default value (UTC).

This change was discussed with and acknowledge by @brusch