### PR TITLE
Versions update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
                     - { tag: 'v1.4', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: 'v2.1', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: '2.x', php: '8.2', distro: bullseye, version-override: "v2-dev", latest-tag: false }
-                    - { tag: 'v3.6', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }
-                    - { tag: 'v3.6', php: '8.3', distro: bookworm, version-override: "", latest-tag: true }
+                    - { tag: 'v3.7', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }
+                    - { tag: 'v3.7', php: '8.3', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '3.x', php: '8.2', distro: bookworm, version-override: "v3-dev", latest-tag: false }
                     - { tag: '3.x', php: '8.3', distro: bookworm, version-override: "v3-dev", latest-tag: false }
                     - { tag: '4.x', php: '8.3', distro: bookworm, version-override: "v4-dev", latest-tag: false }


### PR DESCRIPTION
This pull request updates the release workflow to build and tag Docker images for the new `v3.7` release, replacing the previous `v3.6` images. This ensures the latest release is built and marked as the current version.

Release workflow updates:

* Updated the `.github/workflows/release.yml` matrix to build and tag Docker images for `v3.7` (with PHP 8.2 and 8.3 on `bookworm`), and removed the corresponding `v3.6` entries. (`.github/workflows/release.yml`)