### PR TITLE
Prepare v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,9 @@ jobs:
                     - { tag: 'v3.7', php: '8.3', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '3.x', php: '8.2', distro: bookworm, version-override: "v3-dev", latest-tag: false }
                     - { tag: '3.x', php: '8.3', distro: bookworm, version-override: "v3-dev", latest-tag: false }
-                    - { tag: '4.x', php: '8.3', distro: bookworm, version-override: "v4-dev", latest-tag: false }
+                    - { tag: 'v4.0', php: '8.4', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '4.x', php: '8.4', distro: bookworm, version-override: "v4-dev", latest-tag: false }
+
 
         steps:
             -   uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG PHP_VERSION="8.3"
+ARG PHP_VERSION="8.4"
 ARG DEBIAN_VERSION="bookworm"
 
 FROM php:${PHP_VERSION}-fpm-${DEBIAN_VERSION} AS pimcore_php_min


### PR DESCRIPTION
This pull request updates the project to use PHP 8.4 as the default version in both the Docker build process and the release workflow. The most important changes include updating the default PHP version in the `Dockerfile` and adjusting the release workflow to build and tag images for PHP 8.4.

**PHP Version Updates:**

* Updated the default PHP version to 8.4 in the `Dockerfile` by changing the `PHP_VERSION` build argument.
* Modified the release workflow in `.github/workflows/release.yml` to add new build and tag entries for PHP 8.4, including a new `v4.0` tag marked as the latest.
* Removed the previous `4.x` PHP 8.3 build entry from the release workflow, focusing future 4.x builds on PHP 8.4.