### PR TITLE
Provenance fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,8 @@ jobs:
                         fi
 
                         docker build --output "type=image,push=$PUSH" \
+                            --provenance=false \
+                            --platform "linux/${ARCH_TAG}" \
                             --target="pimcore_php_$imageVariant" \
                             --build-arg PHP_VERSION="${PHP_VERSION}" \
                             --build-arg DEBIAN_VERSION="${DEBIAN_VERSION}" \


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process in the GitHub Actions workflow for releases. The change adds two new arguments to the `docker build` command to improve build reproducibility and platform targeting.

- **Build process improvements:**
  * [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R125-R126): Added `--provenance=false` to disable provenance generation and `--platform "linux/${ARCH_TAG}"` to specify the target platform during Docker builds.