### PR TITLE
Pin redis and add ssl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
                     - { php: '8.3', distro: bookworm }
                     - { php: '8.4', distro: bookworm }
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
             -   name: Build Image
                 run: |
                     set -ex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
                             docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
                         fi
 
-                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2025.x-dev pimcore --no-scripts
+                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2025.4.0 pimcore --no-scripts
 
                         if [ "$imageVariant" != "min" ]; then
                             docker run -v "$(pwd)/.github/files":/var/www/html --rm pimcore-image php test_heif.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ RUN set -eux; \
         libicu-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
+        libssl-dev \
         libzip-dev \
+        openssl \
         zlib1g-dev \
         librabbitmq-dev \
     ; \
@@ -143,7 +145,7 @@ RUN set -eux; \
     pecl install -f \
         apcu \
         imagick \
-        redis \
+        "redis<6.1" \
     ; \
     docker-php-ext-enable \
         apcu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,8 @@ CMD ["php-fpm"]
 
 FROM pimcore_php_min AS pimcore_php_default
 
+ARG REDIS_EXT_VERSION
+
 RUN set -eux; \
     \
     build-install.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 ARG PHP_VERSION="8.4"
 ARG DEBIAN_VERSION="bookworm"
+ARG REDIS_EXT_VERSION="6.0.0"
 
 FROM php:${PHP_VERSION}-fpm-${DEBIAN_VERSION} AS pimcore_php_min
 
@@ -145,7 +146,7 @@ RUN set -eux; \
     pecl install -f \
         apcu \
         imagick \
-        "redis<6.1" \
+        redis-${REDIS_EXT_VERSION} \
     ; \
     docker-php-ext-enable \
         apcu \


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve compatibility and address dependency requirements. The most notable changes are the addition of new system libraries and a version constraint on a PHP extension.

Dependency updates:

* Added `libssl-dev` and `openssl` to the list of system packages to ensure proper SSL support in the build environment.
* Updated the `redis` PHP extension installation to explicitly require a version less than 6.1, likely to avoid compatibility issues with newer versions.