### PR TITLE
Pin redis and add ssl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
                     - { php: '8.5', distro: trixie, composerOptions: '--ignore-platform-reqs' }
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
             -   name: Build Image
                 run: |
                     set -ex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - { php: '8.3', distro: bookworm }
                     - { php: '8.4', distro: bookworm }
                     - { php: '8.5', distro: trixie, composerOptions: '--ignore-platform-reqs' }
 
@@ -51,7 +50,7 @@ jobs:
                             docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
                         fi
 
-                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2025.x-dev pimcore --no-scripts ${{ matrix.composerOptions }}
+                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2026.x-dev pimcore --no-scripts ${{ matrix.composerOptions }}
 
                         if [ "$imageVariant" != "min" ]; then
                             docker run -v "$(pwd)/.github/files":/var/www/html --rm pimcore-image php test_heif.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 ARG PHP_VERSION="8.5"
 ARG DEBIAN_VERSION="trixie"
+ARG REDIS_PECL_VERSION="6.0.2"
 
 FROM php:${PHP_VERSION}-fpm-${DEBIAN_VERSION} AS pimcore_php_min
 
@@ -100,6 +101,7 @@ CMD ["php-fpm"]
 FROM pimcore_php_min AS pimcore_php_default
 
 ARG DEBIAN_VERSION
+ARG REDIS_PECL_VERSION
 
 RUN set -eux; \
     \
@@ -142,7 +144,7 @@ RUN set -eux; \
     pecl install -f \
         apcu \
         imagick \
-        "redis<6.1" \
+        "redis-${REDIS_PECL_VERSION}" \
     ; \
     docker-php-ext-enable \
         apcu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN set -eux; \
         libicu-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
+        libssl-dev \
         libzip-dev \
+        openssl \
         zlib1g-dev \
         librabbitmq-dev \
     ; \
@@ -140,7 +142,7 @@ RUN set -eux; \
     pecl install -f \
         apcu \
         imagick \
-        redis \
+        "redis<6.1" \
     ; \
     docker-php-ext-enable \
         apcu \


### PR DESCRIPTION
This pull request updates the `Dockerfile` to address dependency and compatibility issues. The most significant changes are the addition of required libraries for SSL functionality and the restriction of the Redis extension version to ensure compatibility.

**Dependency updates:**

* Added `libssl-dev` and `openssl` to the list of installed packages to support SSL features.

**Extension compatibility:**

* Modified the `pecl install` command to restrict the installed Redis extension to versions lower than 6.1, preventing potential incompatibility issues with newer versions.