### PR TITLE
Bump checkout to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
                     # - { tag: '5.x', php: '8.5', distro: trixie, version-override: "v5-dev", latest-tag: false } 
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v5
                 with:
                     ref: ${{ matrix.build.tag }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
                             docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
                         fi
 
-                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2026.x-dev pimcore --no-scripts ${{ matrix.composerOptions }}
+                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2025.x-dev pimcore --no-scripts ${{ matrix.composerOptions }}
 
                         if [ "$imageVariant" != "min" ]; then
                             docker run -v "$(pwd)/.github/files":/var/www/html --rm pimcore-image php test_heif.php

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
                             docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
                         fi
 
-                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2025.x-dev pimcore --no-scripts ${{ matrix.composerOptions }}
+                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2026.x-dev pimcore --no-scripts ${{ matrix.composerOptions }}
 
                         if [ "$imageVariant" != "min" ]; then
                             docker run -v "$(pwd)/.github/files":/var/www/html --rm pimcore-image php test_heif.php


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by upgrading the `actions/checkout` action from version 4 to version 5 in the `.github/workflows/release.yml` file. This ensures the workflow uses the latest features and security updates.

- Upgraded the `actions/checkout` step from version 4 to version 5 in the release workflow (`.github/workflows/release.yml`).

Node20 used in checkout 4 is eol, so bumping to v5