### PR TITLE
Removed php8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - { php: '8.3', distro: bookworm }
                     - { php: '8.4', distro: bookworm }
                     - { php: '8.5', distro: trixie, composerOptions: '--ignore-platform-reqs' }
 


### PR DESCRIPTION
This pull request makes a minor update to the test workflow configuration by removing PHP 8.3 from the test matrix in `.github/workflows/test.yml`. This means our automated tests will no longer run against PHP 8.3.