### PR TITLE
Use mlocati/docker-php-extension-installer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
                             --build-arg DEBIAN_VERSION="${{ matrix.distro }}" \
                             .
 
-                        # Verify core extensions are loaded in all variants
+                        # Verify core extensions are loaded in all flavors
                         docker run --rm pimcore-image php -m | grep -Fx 'amqp'
                         docker run --rm pimcore-image php -m | grep -Fx 'bcmath'
                         docker run --rm pimcore-image php -m | grep -Fx 'exif'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,24 @@ jobs:
                             --build-arg DEBIAN_VERSION="${{ matrix.distro }}" \
                             .
 
+                        # Verify core extensions are loaded in all variants
+                        docker run --rm pimcore-image php -m | grep -Fx 'amqp'
+                        docker run --rm pimcore-image php -m | grep -Fx 'bcmath'
+                        docker run --rm pimcore-image php -m | grep -Fx 'exif'
+                        docker run --rm pimcore-image php -m | grep -Fx 'gd'
+                        docker run --rm pimcore-image php -m | grep -Fx 'intl'
+                        docker run --rm pimcore-image php -m | grep -Fx 'pcntl'
+                        docker run --rm pimcore-image php -m | grep -Fx 'pdo_mysql'
+                        docker run --rm pimcore-image php -m | grep -Fx 'sockets'
+                        docker run --rm pimcore-image php -m | grep -Fx 'zip'
+
                         if [ "$imageVariant" != "min" ]; then
                             # Test that Imagick is installed
                             docker run --rm pimcore-image sh -c 'php -m | grep imagick'
+                        fi
+
+                        if [ "$imageVariant" == "max" ]; then
+                            docker run --rm pimcore-image php -m | grep -Fx 'soap'
                         fi
                     
                         if [ "$imageVariant" == "debug" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 
 ARG PHP_VERSION="8.5"
 ARG DEBIAN_VERSION="trixie"
+ARG PHP_EXTENSION_INSTALLER_VERSION="2.11.1"
+
+FROM mlocati/php-extension-installer:${PHP_EXTENSION_INSTALLER_VERSION} AS php_extension_installer
 
 FROM php:${PHP_VERSION}-fpm-${DEBIAN_VERSION} AS pimcore_php_min
 
@@ -22,7 +25,7 @@ RUN set -eux; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     install-php-extensions \
         amqp \
         bcmath \
@@ -103,7 +106,7 @@ RUN set -eux; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     install-php-extensions \
         apcu \
         imagick \
@@ -124,7 +127,7 @@ RUN set -eux; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     install-php-extensions \
         soap
 
@@ -132,7 +135,7 @@ CMD ["php-fpm"]
 
 FROM pimcore_php_default AS pimcore_php_debug
 
-RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN --mount=type=bind,from=php_extension_installer,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
     install-php-extensions \
         xdebug
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,9 @@ FROM php:${PHP_VERSION}-fpm-${DEBIAN_VERSION} AS pimcore_php_min
 
 ARG DEBIAN_VERSION
 
-COPY --chmod=0755 files/build-*.sh /usr/local/bin/
-
 RUN set -eux; \
     \
     echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries; \
-    DPKG_ARCH="$(dpkg --print-architecture)"; \
     echo "deb http://deb.debian.org/debian ${DEBIAN_VERSION}-backports main" > /etc/apt/sources.list.d/backports.list; \
     apt-get update; \
     apt-get upgrade -y; \
@@ -22,20 +19,12 @@ RUN set -eux; \
         iproute2 \
         unzip \
     ; \
-    \
-    # dependencies for building PHP extensions
-    apt-get install -y \
-        libicu-dev \
-        libjpeg62-turbo-dev \
-        libpng-dev \
-        libzip-dev \
-        zlib1g-dev \
-        librabbitmq-dev \
-    ; \
-    \
-    docker-php-ext-configure gd --enable-gd --with-jpeg; \
-    docker-php-ext-configure pcntl --enable-pcntl; \
-    docker-php-ext-install \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+    install-php-extensions \
+        amqp \
         bcmath \
         exif \
         gd \
@@ -43,20 +32,7 @@ RUN set -eux; \
         pcntl \
         pdo_mysql \
         sockets \
-        zip \
-    ; \
-    \
-    pecl install -f \
-        amqp \
-    ; \
-    docker-php-ext-enable \
-        amqp \
-    ; \
-    build-cleanup.sh; \
-    \
-    ldconfig /usr/local/lib; \
-    \
-    sync
+        zip
 
 COPY files/conf/php/php.ini /usr/local/etc/php/conf.d/20-pimcore.ini
 COPY files/conf/php-fpm/php-fpm.conf /usr/local/etc/php-fpm.d/zz-www.conf
@@ -102,9 +78,6 @@ ARG DEBIAN_VERSION
 
 RUN set -eux; \
     \
-    build-install.sh; \
-    \
-    DPKG_ARCH="$(dpkg --print-architecture)"; \
     apt-get update; \
     \
     # tools used by Pimcore
@@ -123,37 +96,18 @@ RUN set -eux; \
         webp \
     ; \
     \
-    # dependencies for building PHP extensions
-    apt-get install -y \
-        libfreetype6-dev \
-        libwebp-dev \
-    ; \
-    \
     # ImageMagick
     apt-get install -y \
         imagemagick \
-        libmagickwand-dev \
     ; \
-    \
-    docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp; \
-    docker-php-ext-install gd; \
-    \
-    pecl install -f \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+    install-php-extensions \
         apcu \
         imagick \
-        redis \
-    ; \
-    docker-php-ext-enable \
-        apcu \
-        imagick \
-        redis \
-    ; \
-    \
-    build-cleanup.sh; \
-    \
-    ldconfig /usr/local/lib; \
-    \
-    sync
+        redis
 
 CMD ["php-fpm"]
 
@@ -161,39 +115,28 @@ FROM pimcore_php_default AS pimcore_php_max
 
 RUN set -eux; \
     \
-    build-install.sh; \
-    \
+    apt-get update; \
     apt-get install -y \
         chromium-sandbox \
-        libkrb5-dev \
         libreoffice \
-        libxml2-dev \
         openssl \
     ; \
-    \
-    docker-php-ext-install \
-        soap \
-    ; \
-    docker-php-ext-enable \
-        soap \
-    ; \
-    \
-    build-cleanup.sh; \
-    \
-    sync
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+    install-php-extensions \
+        soap
 
 CMD ["php-fpm"]
 
 FROM pimcore_php_default AS pimcore_php_debug
 
+RUN --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+    install-php-extensions \
+        xdebug
+
 RUN set -eux; \
-    \
-    build-install.sh; \
-    \
-    pecl install xdebug; \
-    docker-php-ext-enable xdebug; \
-    \
-    build-cleanup.sh; \
     \
     # For local development, it should be possible to use any local (Git) Composer repository - that's safe in debug image flavor
     git config --global --add safe.directory "*"; \

--- a/files/build-cleanup.sh
+++ b/files/build-cleanup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-
-apt-get remove -y autoconf automake libtool make cmake ninja-build pkg-config build-essential g++ gcc libicu-dev;
-apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* ~/.composer || true
-apt-get autoremove -y
-sync
-

--- a/files/build-install.sh
+++ b/files/build-install.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-
-apt-get update;
-apt-get install -y autoconf automake libtool make cmake ninja-build pkg-config build-essential g++ gcc


### PR DESCRIPTION
Replaces manual docker-php-ext-install/pecl with mlocati/docker-php-extension-installer
which properly handles runtime dependencies