### PR TITLE
Added sbom

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,9 @@ jobs:
         if: github.event_name != 'workflow_dispatch' || inputs.publish
         steps:
             
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v4
+
             -   name: Login to DockerHub Registry
                 run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
@@ -190,9 +193,15 @@ jobs:
                     
                         echo "Processing tag: $tag"
 
-                        docker buildx imagetools create \
-                            --tag "$tag" \
-                            "${tag}-amd64" \
-                            "${tag}-arm64"
+                        # Verify both per-arch images exist in the registry before merging
+                        if docker buildx imagetools inspect "${tag}-amd64" > /dev/null 2>&1 \
+                            && docker buildx imagetools inspect "${tag}-arm64" > /dev/null 2>&1; then
+                            docker buildx imagetools create \
+                                --tag "$tag" \
+                                "${tag}-amd64" \
+                                "${tag}-arm64"
+                        else
+                            echo "Error: Missing per-arch image for $tag, skipping"
+                        fi
     
                     done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,24 +209,3 @@ jobs:
                         docker manifest push "$tag"
     
                     done
-
-    attach-sboms:
-        name: "Attach SBOMs to release"
-        runs-on: ubuntu-22.04
-        needs: process-tags
-        if: (github.event_name != 'workflow_dispatch' || inputs.publish) && startsWith(github.ref, 'refs/tags/')
-        permissions:
-            contents: write
-        steps:
-            -   name: Download all SBOMs
-                uses: actions/download-artifact@v8
-                with:
-                    pattern: sboms_*
-                    path: all-sboms
-                    merge-multiple: true
-
-            -   name: Attach SBOMs to GitHub release
-                uses: softprops/action-gh-release@v2
-                with:
-                    files: all-sboms/*.cdx.json
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
                 with:
                     ref: ${{ matrix.build.tag }}
 
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v4
+
             -   name: Login to DockerHub Registry
                 run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
@@ -121,7 +124,7 @@ jobs:
                             TAGS="$TAGS --tag $GHCR_TAG_MAJOR"
                         fi
 
-                        docker build --output "type=image,push=$PUSH" \
+                        docker buildx build --output "type=image,push=$PUSH" \
                             --provenance=false \
                             --sbom=true \
                             --platform "linux/${ARCH_TAG}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,14 +132,6 @@ jobs:
 
                         docker inspect ${IMAGE_NAME}:${TAG} || true;
 
-                        # Extract SBOM from the pushed image attestation
-                        if [[ "$PUSH" == "true" ]]; then
-                            mkdir -p sboms
-                            docker buildx imagetools inspect "${IMAGE_NAME}:${TAG}" \
-                                --format '{{ json .SBOM.CycloneDX }}' > "sboms/sbom-${TAG}.cdx.json" || \
-                                echo "Warning: Could not extract SBOM for ${TAG}"
-                        fi
-
                         # Only aggregate tags if we're publishing
                         if [[ "$PUSH" == "true" ]]; then
                             CLEAN_TAGS="${TAGS//-arm64/}"
@@ -162,13 +154,6 @@ jobs:
                 with:
                     name: aggregated_tags_${{ matrix.runner }}_${{ matrix.build.tag }}_${{ matrix.build.php }}_${{ matrix.build.distro }}_${{ matrix.build.version-override }}_${{ matrix.build.latest-tag }}
                     path: aggregated_tags.txt
-
-            -   name: Upload SBOMs
-                uses: actions/upload-artifact@v7
-                with:
-                    name: sboms_${{ matrix.runner }}_${{ matrix.build.tag }}_${{ matrix.build.php }}_${{ matrix.build.distro }}_${{ matrix.build.version-override }}_${{ matrix.build.latest-tag }}
-                    path: sboms/
-                    if-no-files-found: ignore
         
     process-tags:
         runs-on: ubuntu-22.04
@@ -186,7 +171,7 @@ jobs:
                 uses: actions/download-artifact@v8
                 with:
                     path: artifacts
-                
+
             -   name: Process tags
                 run: |
                     find artifacts -type f -name "aggregated_tags.txt" -exec cat {} + > all_aggregated_tags.txt
@@ -201,11 +186,10 @@ jobs:
                     for tag in "${!UNIQUE_TAGS[@]}"; do
                     
                         echo "Processing tag: $tag"
-                        
-                        docker manifest create "$tag" \
-                        --amend "${tag}-amd64" \
-                        --amend "${tag}-arm64"
 
-                        docker manifest push "$tag"
+                        docker buildx imagetools create \
+                            --tag "$tag" \
+                            "${tag}-amd64" \
+                            "${tag}-arm64"
     
                     done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
 
                         docker build --output "type=image,push=$PUSH" \
                             --provenance=false \
+                            --sbom=true \
                             --platform "linux/${ARCH_TAG}" \
                             --target="pimcore_php_$imageVariant" \
                             --build-arg PHP_VERSION="${PHP_VERSION}" \
@@ -130,6 +131,14 @@ jobs:
                             ${TAGS} .
 
                         docker inspect ${IMAGE_NAME}:${TAG} || true;
+
+                        # Extract SBOM from the pushed image attestation
+                        if [[ "$PUSH" == "true" ]]; then
+                            mkdir -p sboms
+                            docker buildx imagetools inspect "${IMAGE_NAME}:${TAG}" \
+                                --format '{{ json .SBOM.CycloneDX }}' > "sboms/sbom-${TAG}.cdx.json" || \
+                                echo "Warning: Could not extract SBOM for ${TAG}"
+                        fi
 
                         # Only aggregate tags if we're publishing
                         if [[ "$PUSH" == "true" ]]; then
@@ -153,6 +162,13 @@ jobs:
                 with:
                     name: aggregated_tags_${{ matrix.runner }}_${{ matrix.build.tag }}_${{ matrix.build.php }}_${{ matrix.build.distro }}_${{ matrix.build.version-override }}_${{ matrix.build.latest-tag }}
                     path: aggregated_tags.txt
+
+            -   name: Upload SBOMs
+                uses: actions/upload-artifact@v7
+                with:
+                    name: sboms_${{ matrix.runner }}_${{ matrix.build.tag }}_${{ matrix.build.php }}_${{ matrix.build.distro }}_${{ matrix.build.version-override }}_${{ matrix.build.latest-tag }}
+                    path: sboms/
+                    if-no-files-found: ignore
         
     process-tags:
         runs-on: ubuntu-22.04
@@ -193,4 +209,24 @@ jobs:
                         docker manifest push "$tag"
     
                     done
+
+    attach-sboms:
+        name: "Attach SBOMs to release"
+        runs-on: ubuntu-22.04
+        needs: process-tags
+        if: (github.event_name != 'workflow_dispatch' || inputs.publish) && startsWith(github.ref, 'refs/tags/')
+        permissions:
+            contents: write
+        steps:
+            -   name: Download all SBOMs
+                uses: actions/download-artifact@v8
+                with:
+                    pattern: sboms_*
+                    path: all-sboms
+                    merge-multiple: true
+
+            -   name: Attach SBOMs to GitHub release
+                uses: softprops/action-gh-release@v2
+                with:
+                    files: all-sboms/*.cdx.json
 


### PR DESCRIPTION
This pull request updates the Docker image build and release workflow in `.github/workflows/release.yml` to fully adopt Docker Buildx and improve multi-architecture image handling. The main changes involve switching to Buildx for building and merging images, adding build provenance and SBOM generation, and improving safety checks for image manifests.

**Build system modernization:**

* Switched from `docker build` to `docker buildx build` for building images, enabling advanced features and multi-platform support.
* Added the `docker/setup-buildx-action@v4` step to set up Docker Buildx in relevant jobs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R52-R54) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R167-R169)

**Build output and security enhancements:**

* Enabled SBOM (Software Bill of Materials) generation by adding `--sbom=true` to the build command, and explicitly disabled provenance with `--provenance=false`.

**Multi-architecture image publishing improvements:**

* Replaced `docker manifest create/push` with `docker buildx imagetools create`, and added a check to ensure both per-architecture images exist before merging them into a manifest. This prevents manifest creation if an image is missing.