### PR TITLE
using imagemagick from backports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN set -eux; \
     ; \
     \
     # ImageMagick
-    apt-get install -y \
+    apt-get install -y -t ${DEBIAN_VERSION}-backports \
         imagemagick \
     ; \
     apt-get clean; \


### PR DESCRIPTION
This pull request makes a small update to the `Dockerfile` to ensure that `imagemagick` is installed from the Debian backports repository, which can help provide a newer or more secure version of the package.

* Install `imagemagick` using the `-t ${DEBIAN_VERSION}-backports` flag to pull from the backports repository in the `Dockerfile`.