### PR TITLE
Imagemagick from distro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
                             docker run --rm pimcore-image test ! -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
                         fi
 
-                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2025.x-dev pimcore --no-scripts
+                        docker run --rm pimcore-image composer create-project pimcore/skeleton:2025.4.1 pimcore --no-scripts
 
                         if [ "$imageVariant" != "min" ]; then
                             docker run -v "$(pwd)/.github/files":/var/www/html --rm pimcore-image php test_heif.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,8 +134,8 @@ RUN set -eux; \
     \
     # ImageMagick
     apt-get install -y \
-        imagemagick-7 \
-        libmagickwand-7-dev \
+        imagemagick \
+        libmagickwand-dev \
     ; \
     \
     docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp; \


### PR DESCRIPTION
This pull request updates the ImageMagick dependencies in the `Dockerfile` to use the default package names instead of the version-specific ones. This change improves compatibility with various distributions and package repositories.

Dependency updates:

* Replaced `imagemagick-7` with `imagemagick` and `libmagickwand-7-dev` with `libmagickwand-dev` in the list of packages installed by `apt-get` in the `Dockerfile`.