### PR TITLE
Version suported table

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,6 @@ jobs:
                     - ubuntu-22.04
                     - ubuntu-22.04-arm
                 build:
-                    - { tag: '1.x', php: '8.1', distro: bullseye, version-override: "v1-dev", latest-tag: false }
-                    - { tag: '1.x', php: '8.2', distro: bullseye, version-override: "v1-dev", latest-tag: false }
-                    - { tag: 'v1.6', php: '8.1', distro: bullseye, version-override: "", latest-tag: true }
-                    - { tag: 'v1.6', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: 'v2.3', php: '8.2', distro: bullseye, version-override: "", latest-tag: false }
                     - { tag: '2.x', php: '8.2', distro: bullseye, version-override: "v2-dev", latest-tag: false }
                     - { tag: 'v3.8', php: '8.2', distro: bookworm, version-override: "", latest-tag: true }

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ We are basing our images on top of the official PHP and Debian images and provid
 ### PHP images
 ```text
 php8.2-latest # always use the latest PHP 8.2 image
-php8.2-v1 # always point to the latest minor version of v1
-php8.2-v1.0 # pin to specific image version, always using the latest bugfixes from PHP 8.2
-php8.2.5-v1.0 # pin to a specific PHP version & image version 
+php8.2-v2 # always point to the latest minor version of v2
+php8.2-v2.0 # pin to specific image version, always using the latest bugfixes from PHP 8.2
+php8.2.5-v2.0 # pin to a specific PHP version & image version 
 php8.2-dev # development image (build from the default branch) 
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ Use either of the following commands:
 | v5              | ❌  | ❌  | ❌      | ❌      | ❌   | ✅*   |
 
 
-> *) recommended version
+### Pimcore image versions support
+| Image | Supported |
+|-------|-----------|
+| v1    | ❌        |
+| v2    | ✅        |
+| v3    | ✅        |
+| v4    | ✅        |
+| v5    | ✅        |
+
+We are basing our images on top of the official PHP and Debian images and providing support until EOL for the [PHP versions](https://www.php.net/supported-versions.php) and [Debian versions](https://wiki.debian.org/LTS)
 
 ## Examples 
 


### PR DESCRIPTION
This pull request removes support for v1.x Pimcore images and updates the documentation to reflect the currently supported image versions. The main changes are the removal of v1.x build configurations from the release workflow and the addition of a new support matrix in the `README.md`.

**Documentation updates:**

* Added a new "Pimcore image versions support" section to the `README.md`, listing which image versions are currently supported and clarifying the support policy based on PHP and Debian EOL.

**Build and workflow changes:**

* Removed all build configurations for v1.x Pimcore images from the `.github/workflows/release.yml` file, so v1.x images will no longer be built or released.