### PR TITLE
Update PHP version tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,8 @@ jobs:
                     - { tag: 'v3.8', php: '8.3', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '3.x', php: '8.2', distro: bookworm, version-override: "v3-dev", latest-tag: false }
                     - { tag: '3.x', php: '8.3', distro: bookworm, version-override: "v3-dev", latest-tag: false }
-                    - { tag: 'v4.1', php: '8.4', distro: bookworm, version-override: "", latest-tag: true }
+                    - { tag: 'v4.2', php: '8.4', distro: bookworm, version-override: "", latest-tag: true }
                     - { tag: '4.x', php: '8.4', distro: bookworm, version-override: "v4-dev", latest-tag: false }
-                    - { tag: '5.x', php: '8.5', distro: trixie, version-override: "", latest-tag: false }
                     - { tag: 'v5.2', php: '8.5', distro: trixie, version-override: "", latest-tag: true } 
                     - { tag: '5.x', php: '8.5', distro: trixie, version-override: "v5-dev", latest-tag: false } 
 


### PR DESCRIPTION
This pull request updates the release workflow configuration to reflect the latest stable versions for the 4.x and 5.x release lines. The key changes are:

**Release workflow updates:**

* Updated the release job to use the `v4.2` tag with PHP 8.4 as the latest for the 4.x series, replacing the previous `v4.1` tag.
* Removed the `5.x` tag without a version override as a release job, ensuring only the explicit `v5.2` tag is used as the latest for the 5.x series.